### PR TITLE
Changed $baseurl and other URLs from http to https

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-baseurl: "http://acodispo.github.io/Dungeon-World-HTML-SRD"
+baseurl: "https://acodispo.github.io/Dungeon-World-HTML-SRD"
 title: "Dungeon World HTML SRD"
-group: 'groups'
+group: "groups"
 ---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,9 +25,9 @@
           <div class="col-md-6 col-md-offset-1">
 <h1>Dungeon World HTML SRD</h1>
 
-<p><a href="http://www.dungeon-world.com/">Dungeon World</a> is a tabletop roleplaying game by Sage LaTorra and Adam Koebel of Sage Kobold Productions. This document is a System Reference Document (SRD) for that game, prepared in HTML format for reference in a browser.</p>
+<p><a href="https://www.dungeon-world.com/">Dungeon World</a> is a tabletop roleplaying game by Sage LaTorra and Adam Koebel of Sage Kobold Productions. This document is a System Reference Document (SRD) for that game, prepared in HTML format for reference in a browser.</p>
 
-<p>This site was designed with the help of <a href="http://getbootstrap.com/">Bootstrap</a> and built with <a href="http://hugo.spf13.com/">Hugo</a>.</p>
+<p>This site was designed with the help of <a href="https://getbootstrap.com/">Bootstrap</a> and built with <a href="https://hugo.spf13.com/">Hugo</a>.</p>
 
 <p>If you'd like to help out with the project (for instance if you see something that needs fixing), please fork us: <a href="https://github.com/acodispo/Dungeon-World-HTML-SRD">https://github.com/acodispo/Dungeon-World-HTML-SRD</a></p>
 
@@ -35,7 +35,7 @@
 
 <h2 id="license">License</h2>
 
-<p>This site is licensed under the <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a> and the <strong>Open Gaming License</strong>. Please see the <a href="license/">License page</a> for details.</p>
+<p>This site is licensed under the <a href="https://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a> and the <strong>Open Gaming License</strong>. Please see the <a href="license/">License page</a> for details.</p>
           </div>
        </div>
     </div>


### PR DESCRIPTION
This primarily prevents stylesheets from being blocked as mixed content. Right now, the website has no CSS styling on the latest versions of Chrome and Firefox, which both block http content from loading on https pages.

Read more about mixed content error here: [https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content)